### PR TITLE
Update python_version for 3.13

### DIFF
--- a/crits.json
+++ b/crits.json
@@ -12,7 +12,7 @@
     "product_vendor": "MITRE",
     "product_version_regex": ".*",
     "min_phantom_version": "5.1.0",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "latest_tested_versions": [
         "On prem, Version: 4-master"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)